### PR TITLE
Updated Maker timelock 24 hours -> 4 hours.

### DIFF
--- a/data.json
+++ b/data.json
@@ -218,7 +218,7 @@
       "description": "MakerDAO is a platform for issuing stable cryptocurrency that also has a savings like facility",
       "adminKeys": {
         "config": {
-          "timelock": [true, "24 hours"],
+          "timelock": [true, "4 hours"],
           "multisig": [false, "N/A"]
         },
         "opsec": {


### PR DESCRIPTION
Assuming this is referring to the GSM, this changed on March 16th from 24 hours -> 4 hours. 
Sources: 
https://catflip.co/changelog
https://etherscan.io/address/0xd77ad957fcf536d13a17f5d1fffa3987f83376cf#code ln106

Worth noting that this is dynamic and can be changed by governance (although any change must wait for the old timelock value before taking effect.